### PR TITLE
Add `relURL` to relative links

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,14 +6,14 @@
 <nav class="no-print post-nav">
 {{ if .PrevInSection }}
 	<a class="prev-post" href="{{ .PrevInSection.Permalink }}">
-		<img class="icon-text" src="/img/prev.svg"/>
+        <img class="icon-text" src="{{ "/img/prev.svg" | relURL }}"/>
 		{{- .PrevInSection.Title -}}
 	</a>
 {{ end }}
 {{ if .NextInSection }}
 	<a class="next-post" href="{{ .NextInSection.Permalink }}">
 		{{- .NextInSection.Title -}}
-		<img class="icon-text" src="/img/next.svg"/>
+        <img class="icon-text" src="{{ "/img/next.svg" | relURL }}"/>
 	</a>
 {{ end }}
 </nav>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -16,7 +16,7 @@
 				</p>
 				{{ if ne .Kind "home" }}
 				<a href="#brand">
-					<img class="icon-text" src="/img/toup.svg" alt="To Up"/>
+                    <img class="icon-text" src="{{ "/img/toup.svg" | relURL }}" alt="To Up"/>
 					<span>{{ T "toUp" }}</span>
 				</a>
 				{{ end }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -10,11 +10,11 @@
 		{{ end }}
 		
 		{{ if .Site.Params.DebugCSS }}
-		<link rel="stylesheet" href="/css/normalize.css"/>
-		<link rel="stylesheet" href="/css/ui.css"/>
-		<link rel="stylesheet" href="/css/syntax.css"/>
+        <link rel="stylesheet" href="{{ "/css/normalize.css" | relURL }}"/>
+        <link rel="stylesheet" href="{{ "/css/ui.css" | relURL }}"/>
+        <link rel="stylesheet" href="{{ "/css/syntax.css" | relURL }}"/>
 		{{ else }}
-		<link rel="stylesheet" href="/css/ui.min.css"/>
+        <link rel="stylesheet" href="{{ "/css/ui.min.css" | relURL }}"/>
 		{{ end }}
 		
 		{{ range .Site.Params.CustomCSS }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -2,8 +2,8 @@
 	<ul>
 		{{- if not .IsHome -}}
 		<li>
-			<a href="/">
-				<img class="icon-text" src="/img/prev.svg"/>
+			<a href="{{ "/" | relURL }}">
+                <img class="icon-text" src="{{ "/img/prev.svg" | relURL }}"/>
 			</a>
 		</li>
 		{{- end -}}

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -2,13 +2,13 @@
 <nav class="pagination">
     {{ with .Paginator.Prev }}
     <a href="{{ .URL }}">
-    <img class="icon-text" src="/img/prev.svg"/>
+    <img class="icon-text" src="{{ "/img/prev.svg" | relURL }}"/>
     </a>
     {{ end }}
     <span>{{.Paginator.PageNumber}}</span>
     {{ with .Paginator.Next }}
     <a href="{{ .URL }}">
-    <img class="icon-text" src="/img/next.svg"/>
+    <img class="icon-text" src="{{ "/img/next.svg" | relURL }}"/>
     </a>
     {{ end }}
 </nav>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,10 +1,10 @@
 {{ with .Site.Params.Email }}
-<a href="mailto:{{.}}"><img class="icon-social" src="/img/email.svg" alt="Email Me!"/></a>
+<a href="mailto:{{.}}"><img class="icon-social" src="{{ "/img/email.svg" | relURL }}" alt="Email Me!"/></a>
 {{ end }}
 {{ with .Site.Params.Github }}
-<a href="{{.}}"><img class="icon-social" src="/img/github.svg" alt="Github"/></a>
+<a href="{{.}}"><img class="icon-social" src="{{ "/img/github.svg" | relURL }}" alt="Github"/></a>
 {{ end }}
 {{ with .Site.Params.Twitter }}
-<a href="{{.}}"><img class="icon-social" src="/img/twitter.svg" alt="Twitter"/></a>
+<a href="{{.}}"><img class="icon-social" src="{{ "/img/twitter.svg" | relURL }}" alt="Twitter"/></a>
 {{ end }}
-<a href="{{.Site.RSSLink}}" target="_blank"><img class="icon-social" src="/img/feed.svg" alt="Feed"></a>
+<a href="{{.Site.RSSLink}}" target="_blank"><img class="icon-social" src="{{ "/img/feed.svg" | relURL }}" alt="Feed"></a>

--- a/layouts/partials/title.html
+++ b/layouts/partials/title.html
@@ -16,7 +16,7 @@
 			{{ with .Params.tags -}}
 			-
 				{{ range . }}
-				<a href="/tags/{{.}}">{{.}}</a>
+                <a href="{{ print "/tags/" . | urlize | lower | relURL }}">{{.}}</a>
 				{{ end }}
 			{{- end -}}
 			{{- with .Params.workURL -}}


### PR DESCRIPTION
to fix wrong links when `baseUrl` contains some directories as a path